### PR TITLE
fix: 修复无 locale 字段情况下导致的请求异常

### DIFF
--- a/internal/middleware/translations.go
+++ b/internal/middleware/translations.go
@@ -16,7 +16,10 @@ func Translations() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		uni := ut.New(en.New(), zh.New(), zh_Hant_TW.New())
 		locale := c.GetHeader("locale")
-		trans, _ := uni.GetTranslator(locale)
+		trans, ok := uni.GetTranslator(locale)
+		if !ok {
+			trans, _ = uni.GetTranslator("zh")
+		}
 		v, ok := binding.Validator.Engine().(*validator.Validate)
 		if ok {
 			switch locale {


### PR DESCRIPTION
如果不处理 locale 字段为空的情况，大部分时候可以正常响应，但是针对部分极端的边界情况，例如某个字段校验规则为 binding:"min=1"，但是传参时使用空字符串 ""，会导致请求异常

![image](https://user-images.githubusercontent.com/15248446/101618117-7af90e00-3a4c-11eb-903b-1753ff2be899.png)

![image](https://user-images.githubusercontent.com/15248446/101618233-aaa81600-3a4c-11eb-86db-02c13978637f.png)


![image](https://user-images.githubusercontent.com/15248446/101618080-72083c80-3a4c-11eb-9598-074db1b90d6b.png)
