### PR TITLE
fix middleware translations

### DIFF
--- a/global/validator.go
+++ b/global/validator.go
@@ -2,8 +2,11 @@ package global
 
 import (
 	"github.com/go-programming-tour-book/blog-service/pkg/validator"
+
+	ut "github.com/go-playground/universal-translator"
 )
 
 var (
 	Validator *validator.CustomValidator
+	Ut        *ut.UniversalTranslator
 )

--- a/internal/middleware/translations.go
+++ b/internal/middleware/translations.go
@@ -2,37 +2,18 @@ package middleware
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
-	"github.com/go-playground/locales/en"
-	"github.com/go-playground/locales/zh"
-	"github.com/go-playground/locales/zh_Hant_TW"
-	"github.com/go-playground/universal-translator"
-	validator "github.com/go-playground/validator/v10"
-	en_translations "github.com/go-playground/validator/v10/translations/en"
-	zh_translations "github.com/go-playground/validator/v10/translations/zh"
+	"github.com/go-programming-tour-book/blog-service/global"
 )
 
 func Translations() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		uni := ut.New(en.New(), zh.New(), zh_Hant_TW.New())
 		locale := c.GetHeader("locale")
-		trans, _ := uni.GetTranslator(locale)
-		v, ok := binding.Validator.Engine().(*validator.Validate)
-		if ok {
-			switch locale {
-			case "zh":
-				_ = zh_translations.RegisterDefaultTranslations(v, trans)
-				break
-			case "en":
-				_ = en_translations.RegisterDefaultTranslations(v, trans)
-				break
-			default:
-				_ = zh_translations.RegisterDefaultTranslations(v, trans)
-				break
-			}
+		trans, found := global.Ut.GetTranslator(locale)
+		if found {
 			c.Set("trans", trans)
+		} else {
+			c.Set("trans", "en")
 		}
-
 		c.Next()
 	}
 }

--- a/internal/middleware/translations.go
+++ b/internal/middleware/translations.go
@@ -12,7 +12,8 @@ func Translations() gin.HandlerFunc {
 		if found {
 			c.Set("trans", trans)
 		} else {
-			c.Set("trans", "en")
+			enTran, _ := global.Ut.GetTranslator("en")
+			c.Set("trans", enTran)
 		}
 		c.Next()
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-playground/locales/en"
+	"github.com/go-playground/locales/zh"
+	ut "github.com/go-playground/universal-translator"
+	validatorV10 "github.com/go-playground/validator/v10"
+	en_translations "github.com/go-playground/validator/v10/translations/en"
+	zh_translations "github.com/go-playground/validator/v10/translations/zh"
 	"github.com/go-programming-tour-book/blog-service/pkg/tracer"
 
 	"github.com/gin-gonic/gin"
@@ -170,6 +176,22 @@ func setupValidator() error {
 	global.Validator = validator.NewCustomValidator()
 	global.Validator.Engine()
 	binding.Validator = global.Validator
+	uni := ut.New(en.New(), en.New(), zh.New())
+	v, ok := binding.Validator.Engine().(*validatorV10.Validate)
+	if ok {
+		zhTran, _ := uni.GetTranslator("zh")
+		enTran, _ := uni.GetTranslator("en")
+		err := zh_translations.RegisterDefaultTranslations(v, zhTran)
+		if err != nil {
+			return err
+		}
+		err = en_translations.RegisterDefaultTranslations(v, enTran)
+		if err != nil {
+			return err
+		}
+	}
+
+	global.Ut = uni
 
 	return nil
 }


### PR DESCRIPTION
修复middleware中的translations中间件在压测下报[map线程安全的问题](https://github.com/go-programming-tour-book/blog-service/issues/20)

主要是注册翻译器主要是在validator的[map](https://github.com/go-playground/validator/blob/ce34f361cca51e25715399ab801c5e1c01d02d89/validator_instance.go#L294)中注册的 所以只用注册一次就够了 后面翻译验证错误时 拿出原本存在global的universal-translator即可复用之前用于注册的Translator