### PR TITLE
fix:修复2.8.6.7 接口验证时参数绑定失败 header中参数需做额外处理

### DIFF
--- a/pkg/app/form.go
+++ b/pkg/app/form.go
@@ -34,6 +34,14 @@ func (v ValidErrors) Errors() []string {
 
 func BindAndValid(c *gin.Context, v interface{}) (bool, ValidErrors) {
 	var errs ValidErrors
+	appKey := c.GetHeader("app_key")
+	appSecret := c.GetHeader("app_secret")
+	if appKey != "" && appSecret != "" {
+		v = struct {
+			app_key    string
+			app_secret string
+		}{app_key: appKey, app_secret: appSecret}
+	}
 	err := c.ShouldBind(v)
 	if err != nil {
 		v := c.Value("trans")


### PR DESCRIPTION
在第2.8.6.7章节中，我尝试使用常规的 `-H` 标志执行操作，但未能获得期望的结果。在大多数人的评论中，都收到了如下响应：

```json
{
  "code": 10000001,
  "details": ["AppKey为必填字段", "AppSecret为必填字段"],
  "msg": "入参错误"
}
在书评中，有人提到可以使用 -d xx=xx 的方式，但这并不符合我们在开发中的实际需求。这类信息应该从请求头中传递，而不是放在请求体中。

原因是，err := c.ShouldBind(v) 是Gin框架中用于将请求中的数据绑定到结构体（或其他类型）变量 v 上的方法。Gin框架会根据请求的 Content-Type（通常是JSON或表单数据）来确定从哪里获取参数，并将这些参数映射到结构体 v 中。如果要获取请求头中的参数，可以使用Gin框架的上下文对象 c 的 Request 成员来访问请求头信息。